### PR TITLE
Handle Supabase signup auto login

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'router.dart';
 import 'package:uni_links/uni_links.dart';
 import 'dart:async';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'services/auth_service.dart';
 
 // Removed page imports moved to router.dart
 
@@ -17,6 +18,13 @@ Future<void> main() async {
   );
   // Listen for incoming links for password reset
   final initialLink = await getInitialLink();
+  if (initialLink != null) {
+    final uri = Uri.tryParse(initialLink);
+    if (uri != null) {
+      await AuthService.maybeCompleteSignup(uri);
+    }
+  }
+  await AuthService.maybeCompleteSignup(Uri.base);
   if (initialLink != null && initialLink.contains('type=recovery')) {
     runApp(
         const ProviderScope(child: LuminaApp(initialRoute: '/reset-password')));

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -91,9 +91,11 @@ GoRouter buildRouter([String? initialRoute]) {
     redirect: (context, state) {
       final fragment = Uri.base.fragment;
       final fullUrl = Uri.base.toString();
+      final signupRedirect = AuthService.isSignupRedirect(Uri.base);
       final hasAuthTokens = _looksLikeAuthToken(fragment) ||
           fullUrl.contains('access_token=') ||
-          fullUrl.contains('token_type=bearer');
+          fullUrl.contains('token_type=bearer') ||
+          signupRedirect;
 
       final user = Supabase.instance.client.auth.currentUser;
       final session = Supabase.instance.client.auth.currentSession;

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -45,6 +45,95 @@ class AuthService extends ChangeNotifier {
     return _AuthStateNotifier();
   }
 
+  /// Extracts the auth-related parameters from a [Uri] that Supabase uses when
+  /// redirecting back to the application.
+  ///
+  /// Supabase can return parameters either in the query string or the hash
+  /// fragment, depending on the flow (email confirmations typically use the
+  /// query string while magic links use the hash). This helper consolidates
+  /// those values into a single map.
+  static Map<String, String> _collectAuthParams(Uri uri) {
+    final params = <String, String>{};
+
+    void addParams(Map<String, String> source) {
+      source.forEach((key, value) {
+        if (value.isEmpty) return;
+        params.putIfAbsent(key, () => value);
+      });
+    }
+
+    addParams(uri.queryParameters);
+    addParams(_parseFragmentParameters(uri.fragment));
+
+    return params;
+  }
+
+  /// Parses a hash fragment (the part after '#') into key/value pairs while
+  /// safely ignoring non-query fragments such as `#/login`.
+  static Map<String, String> _parseFragmentParameters(String fragment) {
+    if (fragment.isEmpty) return <String, String>{};
+
+    // Remove any leading slash GoRouter might add (e.g. '#/login').
+    final trimmed = fragment.startsWith('/') ? fragment.substring(1) : fragment;
+
+    // Some redirects include a path segment before the query (e.g. 'callback?').
+    final queryPortion = trimmed.contains('?')
+        ? trimmed.substring(trimmed.indexOf('?') + 1)
+        : trimmed;
+
+    if (!queryPortion.contains('=')) return <String, String>{};
+
+    try {
+      return Uri.splitQueryString(queryPortion);
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+
+  /// Determines whether the provided [uri] represents a Supabase signup
+  /// confirmation redirect (i.e. the user clicked the confirm-email link).
+  static bool isSignupRedirect(Uri uri) {
+    final params = _collectAuthParams(uri);
+    final type = params['type'];
+    final token = params['token'] ?? params['token_hash'];
+    return type == 'signup' && token != null && token.isNotEmpty;
+  }
+
+  /// Attempts to complete a Supabase email-signup confirmation flow by
+  /// exchanging the provided redirect parameters for an authenticated session.
+  ///
+  /// Returns `true` if Supabase responds with a valid session.
+  static Future<bool> maybeCompleteSignup(Uri uri) async {
+    if (!isSignupRedirect(uri)) {
+      return false;
+    }
+
+    final session = Supabase.instance.client.auth.currentSession;
+    if (session != null && !session.isExpired) {
+      return false; // Already authenticated.
+    }
+
+    final params = _collectAuthParams(uri);
+    final token = params['token'] ?? params['token_hash'];
+    final email = params['email'];
+
+    if (token == null || token.isEmpty) {
+      return false;
+    }
+
+    try {
+      final response = await Supabase.instance.client.auth.verifyOTP(
+        type: OtpType.signup,
+        token: token,
+        email: email,
+      );
+      return response.session != null;
+    } catch (error) {
+      debugPrint('Failed to complete signup verification: $error');
+      return false;
+    }
+  }
+
   /// Safely resolve the current role for a Supabase [User].
   /// Falls back to app_metadata, then the provided [fallbackRole].
   static String resolveUserRole(User? user, {String fallbackRole = 'admin'}) {


### PR DESCRIPTION
## Summary
- exchange Supabase signup confirmation redirects for a valid session before bootstrapping the app
- detect signup confirmation parameters during routing so guards wait for the session to be established

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce538a5e00833181a4e3788ea90053